### PR TITLE
Add Docker Compose setup for multi-service application

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,20 @@
+# This .env file is used by docker-compose.
+# Variables set here can override those defined in docker-compose.yml or provide
+# environment-specific configurations.
+
+# For the current Docker Compose setup, most service-specific environment variables
+# are defined directly in the docker-compose.yml file (e.g., service URLs, internal paths).
+
+# The Go backend is configured with CONFIG_PATH=/app/config.json. If this file is
+# essential and not auto-generated, its provision needs to be handled, potentially
+# by mounting a config file or initializing it.
+
+# Variables from .env.example related to external services (Azure, Database, Redis)
+# would be configured here if those services were being connected to by this
+# Docker Compose setup. For example:
+# DB_HOST=your_db_host
+# DB_USER=your_db_user
+# DB_PASSWORD=your_db_password
+# etc.
+
+COMPOSE_PROJECT_NAME=nivai_dashboard

--- a/README.md
+++ b/README.md
@@ -7,7 +7,56 @@ The platform consists of three main services:
 2.  **Python API:** Performs intensive physical statistics calculations on tracking and event data.
 3.  **Next.js Frontend:** Provides the user interface for uploading data, viewing matches, and analyzing dashboards.
 
-## 1. Prerequisites
+## Running the Platform with Docker Compose
+
+This is the recommended way to run the entire NIVAI Football Analytics Platform for development and testing, as it simplifies setup and ensures consistency across services.
+
+### Prerequisites for Docker Compose
+
+*   **Docker Desktop:** Installed and running on your system. Download from [https://www.docker.com/products/docker-desktop/](https://www.docker.com/products/docker-desktop/).
+
+### Configuration
+
+1.  **Environment Variables:** A `.env` file in the project root can be used to set environment variables for `docker-compose`. An example is `COMPOSE_PROJECT_NAME=nivai_dashboard`. Service-specific variables like database credentials or cloud keys can also be placed here if not already defined in the `docker-compose.yml` or if you need to override them.
+    The `docker-compose.yml` file is pre-configured for inter-service communication (e.g., frontend calling backend, backend calling python-api).
+
+2.  **Shared Data:** The `docker-compose.yml` defines a named volume (`shared_data`) that is mounted into both the Go Backend (`/data/shared`) and the Python API (`/data/shared`). This volume is used for storing uploaded match files (tracking data, event data) so that the Python API can access files saved by the Go Backend. The `EXTERNAL_DATA_MOUNT` environment variable for the Go Backend is set to `/data/shared` within its container.
+
+### Running the Application
+
+1.  **Open a terminal** in the root directory of the project (where `docker-compose.yml` is located).
+2.  **Build and start all services:**
+    ```bash
+    docker-compose up --build
+    ```
+    *   The `--build` flag ensures images are built if they don't exist or if Dockerfiles have changed.
+    *   To run in detached mode (in the background), add the `-d` flag: `docker-compose up --build -d`.
+3.  **Accessing Services:**
+    *   **Frontend (Main Application):** `http://localhost:3000`
+    *   **Go Backend API:** `http://localhost:8080`
+    *   **Python API:** `http://localhost:8081` (primarily for internal use by the Go backend)
+
+### Stopping the Application
+
+1.  If running in the foreground (without `-d`), press `Ctrl+C` in the terminal.
+2.  If running in detached mode, or to ensure all services and networks are removed:
+    ```bash
+    docker-compose down
+    ```
+    *   To also remove volumes (including the `shared_data` volume, which will delete all uploaded match data stored in it):
+        ```bash
+        docker-compose down -v
+        ```
+
+### Notes
+
+*   The first time you run `docker-compose up --build`, it might take some time to download base images and build the application images.
+*   Log output from all services will be aggregated in your terminal if running in the foreground. If detached, use `docker-compose logs -f` to follow logs, or `docker-compose logs <service_name>` for specific service logs.
+*   The section "Manual Setup: Data Storage/Access Notes" below provides more context on how data is shared, which is handled by the Docker volume in this setup.
+
+## Manual Setup: Prerequisites
+
+These instructions are for setting up each service manually, without the primary Docker Compose environment.
 
 Ensure the following software is installed on your development machine:
 
@@ -17,9 +66,9 @@ Ensure the following software is installed on your development machine:
     *   (Alternatively, Yarn can be used if preferred for frontend package management).
 *   **Python:** Version 3.9 or higher.
 *   **Poetry:** Python dependency management tool. Follow installation instructions at [https://python-poetry.org/docs/](https://python-poetry.org/docs/).
-*   **(Optional) Docker & Docker Compose:** While not covered in these manual setup instructions, Docker can be used for a more isolated and reproducible multi-service environment.
+*   **Docker & Docker Compose:** For manual setup, Docker is not strictly required unless you plan to containerize parts of it yourself. If you wish to use the primary Docker Compose setup, see the section "Running the Platform with Docker Compose".
 
-## 2. Configuration
+## Manual Setup: Configuration
 
 Each service may require environment variables for proper configuration. It's recommended to use `.env` files where supported (e.g., `backend/.env`, `frontend/.env.local`). Example environment files (`.env.example`) are provided in the respective service directories.
 
@@ -27,7 +76,7 @@ Each service may require environment variables for proper configuration. It's re
 
 *   **`PYTHON_API_URL`**: The full URL of the Python statistics API.
     *   Example: `PYTHON_API_URL=http://localhost:8081`
-*   **`EXTERNAL_DATA_MOUNT`**: The base path on the host machine where uploaded files (videos, tracking data, event data) are stored. This path must be accessible by both the Go backend (for writing) and the Python API (for reading). See section "6. Data Storage/Access Notes" for critical details.
+*   **`EXTERNAL_DATA_MOUNT`**: The base path on the host machine where uploaded files (videos, tracking data, event data) are stored. This path must be accessible by both the Go backend (for writing) and the Python API (for reading). See section "Manual Setup: Data Storage/Access Notes" for critical details.
     *   Example: `EXTERNAL_DATA_MOUNT=/path/to/your/nivai_data_storage`
     *   The Go service's `FileStorageService` will create subdirectories within this path (e.g., `/path/to/your/nivai_data_storage/videos/...`).
 *   **`SERVER_PORT`**: Port on which the Go backend will run.
@@ -48,7 +97,7 @@ Each service may require environment variables for proper configuration. It's re
     *   If this is not set, frontend `fetch` calls to relative paths like `/api/v1/...` assume the Go backend is served on the same origin as the Next.js app (e.g., port 3000), or that Next.js rewrites/proxies are configured in `next.config.ts` to route these requests to the Go backend. The current implementation in frontend pages uses relative paths like `/api/v1/videos`, implying such a proxy or same-origin setup.
 *   Create a `.env.local` file in the `frontend/` directory by copying from `.env.local.example` if it exists, and modify as needed.
 
-## 3. Running the Services
+## Manual Setup: Running Individual Services
 
 Run each service in a separate terminal window.
 
@@ -115,7 +164,7 @@ Run each service in a separate terminal window.
     (or `yarn dev`)
     The frontend will typically be available at `http://localhost:3000`.
 
-## 4. Order of Startup
+## Manual Setup: Order of Startup
 
 While services should ideally be resilient, the recommended startup order for a smooth experience is:
 
@@ -123,7 +172,7 @@ While services should ideally be resilient, the recommended startup order for a 
 2.  **Go Backend:** Depends on the Python API for some functionalities (triggering processing, getting analytics status).
 3.  **Next.js Frontend:** Depends on the Go Backend for API calls.
 
-## 5. Accessing the Application
+## Manual Setup: Accessing the Application
 
 Once all services are running:
 
@@ -133,7 +182,7 @@ Once all services are running:
     *   **View Matches:** `http://localhost:3000/matches`
     *   **Match Dashboard:** (Navigate from "View Matches" page by clicking a match) e.g., `http://localhost:3000/dashboard/your_match_id`
 
-## 6. Data Storage/Access Notes (Critical for Functionality)
+## Manual Setup: Data Storage/Access Notes
 
 For the system to function correctly, especially the analytics processing, both the Go Backend and the Python API must have access to the same file storage location for tracking and event data.
 
@@ -144,8 +193,6 @@ For the system to function correctly, especially the analytics processing, both 
     *   The simplest way to achieve this locally is to run both the Go Backend and Python API processes on the same machine.
     *   Set the `EXTERNAL_DATA_MOUNT` environment variable for the Go Backend to a directory on your local filesystem (e.g., `/Users/yourname/nivai_data` or `/mnt/nivai_data`).
     *   The Python API, running as a local process, will then be able to access these files directly using the paths provided by the Go backend.
-*   **Dockerized/Containerized Setup (Future Consideration):**
-    *   If running services in Docker containers, this shared access would typically be managed using Docker volumes. A volume would be mounted into both the Go Backend container and the Python API container at paths that align with how `EXTERNAL_DATA_MOUNT` and the Python API's file access are configured.
 
 Ensure that the user running the Python API process has read permissions for the directories and files created by the Go Backend process within the `EXTERNAL_DATA_MOUNT` location.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.8'
+
+services:
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: ../infrastructure/docker/frontend.Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: http://backend:8080/api/v1
+    depends_on:
+      - backend
+
+  backend:
+    build:
+      context: .
+      dockerfile: ./infrastructure/docker/backend.Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      PYTHON_API_URL: http://python-api:8081
+      EXTERNAL_DATA_MOUNT: /data/shared
+      SERVER_PORT: 8080
+      SERVER_HOST: 0.0.0.0
+      GIN_MODE: release
+      CONFIG_PATH: /app/config.json
+    volumes:
+      - shared_data:/data/shared
+    depends_on:
+      - python-api
+
+  python-api:
+    build:
+      context: ./python_api
+      dockerfile: Dockerfile
+    ports:
+      - "8081:8081"
+    volumes:
+      - shared_data:/data/shared
+    environment:
+      PYTHONUNBUFFERED: 1
+
+volumes:
+  shared_data: {}

--- a/python_api/Dockerfile
+++ b/python_api/Dockerfile
@@ -1,0 +1,23 @@
+# 1. Start from the python:3.9-slim base image
+FROM python:3.9-slim
+
+# 2. Install Poetry
+RUN pip install poetry
+
+# 3. Set the working directory to /app
+WORKDIR /app
+
+# 4. Copy pyproject.toml and poetry.lock files
+COPY pyproject.toml poetry.lock /app/
+
+# 5. Install dependencies
+RUN poetry install --no-dev --no-interaction --no-ansi
+
+# 6. Copy the src directory
+COPY src /app/src/
+
+# 7. Expose port 8081
+EXPOSE 8081
+
+# 8. Set the default command
+CMD ["poetry", "run", "uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "8081"]


### PR DESCRIPTION
This commit introduces a Docker Compose configuration to simplify the setup and execution of the frontend, backend (Go), and Python API services.

Key changes:
- Added `python_api/Dockerfile` to containerize the Python FastAPI service using Poetry for dependency management.
- Created `docker-compose.yml` in the project root, defining the three services (frontend, backend, python-api) with appropriate build contexts, port mappings, environment variables for inter-service communication, and a shared volume (`shared_data`) for data exchange between the backend and Python API.
- Added a root `.env` file to support Docker Compose specific configurations (e.g., `COMPOSE_PROJECT_NAME`) and serve as a template for other environment variables.
- Verified that existing Dockerfiles for the frontend and backend are compatible with the Docker Compose build contexts.
- Updated `README.md` significantly:
    - Added a new primary section detailing how to run the entire platform using `docker-compose up`.
    - Restructured existing manual setup instructions under "Manual Setup" subheadings for clarity.

This setup allows developers to run the complete application with a single `docker-compose up` command, streamlining the development and testing workflow.