### PR TITLE
Fix: Add missing github.com/lib/pq dependency to backend

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
+	github.com/lib/pq v1.10.9
 	github.com/stretchr/testify v1.10.0
 )
 


### PR DESCRIPTION
The backend Docker build was failing with an error indicating that the 'github.com/lib/pq' package (PostgreSQL driver) was not found. This occurred because the dependency was imported in the code but not added to the backend/go.mod file.

This commit updates backend/go.mod to include:
  require (
      // ... other dependencies
      github.com/lib/pq v1.10.9
  )

This ensures that `go mod download` during the Docker build process will fetch the necessary driver, allowing the backend to compile successfully.